### PR TITLE
[WIP] Make send, capture and _capture actions typesafe

### DIFF
--- a/src/reducer-component.ts
+++ b/src/reducer-component.ts
@@ -171,7 +171,7 @@ export function make<P, S, A>(
 /**
  * Send an action to be received by the component `reducer` function.
  */
-export function send<P, S, A>(self: Self<P, S, A>, action: A): void {
+export function send<P, S, A, AA extends A>(self: Self<P, S, A>, action: AA): void {
   const res = self.instance_.__spec.reducer(self.instance_.toSelf(), action)
   switch (res.type) {
     case 'NoUpdate': return
@@ -204,9 +204,9 @@ export function send<P, S, A>(self: Self<P, S, A>, action: A): void {
  *
  * This also calls `preventDefault` on the event.
  */
-export function capture<P, S, A, E extends SyntheticEvent>(
+export function capture<P, S, A, E extends SyntheticEvent, AA extends A>(
   self: Self<P, S, A>,
-  eventFn: (e: E) => A
+  eventFn: (e: E) => AA
 ): EventHandler<E> {
   return function (e) {
     e.preventDefault()
@@ -218,9 +218,9 @@ export function capture<P, S, A, E extends SyntheticEvent>(
 /**
  * Like `capture` but ignores the event and just sends the given action.
  */
-export function _capture<P, S, A, E extends SyntheticEvent>(
+export function _capture<P, S, A, E extends SyntheticEvent, AA extends A>(
   self: Self<P, S, A>,
-  action: A
+  action: AA
 ): EventHandler<E> {
   return capture(self, function () { return action })
 }

--- a/src/reducer-component.ts
+++ b/src/reducer-component.ts
@@ -171,7 +171,7 @@ export function make<P, S, A>(
 /**
  * Send an action to be received by the component `reducer` function.
  */
-export function send<P, S, A, AA extends A>(self: Self<P, S, A>, action: AA): void {
+export function send<P, S, A>(self: Self<P, S, A>, action: A): void {
   const res = self.instance_.__spec.reducer(self.instance_.toSelf(), action)
   switch (res.type) {
     case 'NoUpdate': return
@@ -204,9 +204,9 @@ export function send<P, S, A, AA extends A>(self: Self<P, S, A>, action: AA): vo
  *
  * This also calls `preventDefault` on the event.
  */
-export function capture<P, S, A, E extends SyntheticEvent, AA extends A>(
+export function capture<P, S, A, E extends SyntheticEvent>(
   self: Self<P, S, A>,
-  eventFn: (e: E) => AA
+  eventFn: (e: E) => A
 ): EventHandler<E> {
   return function (e) {
     e.preventDefault()
@@ -218,9 +218,9 @@ export function capture<P, S, A, E extends SyntheticEvent, AA extends A>(
 /**
  * Like `capture` but ignores the event and just sends the given action.
  */
-export function _capture<P, S, A, E extends SyntheticEvent, AA extends A>(
+export function _capture<P, S, A, E extends SyntheticEvent>(
   self: Self<P, S, A>,
-  action: AA
+  action: A
 ): EventHandler<E> {
   return capture(self, function () { return action })
 }

--- a/test/Counter.test.tsx
+++ b/test/Counter.test.tsx
@@ -10,7 +10,7 @@ type State = number
 
 type Action = { type: 'increment' }
 
-const increment = { type: 'increment' }
+const increment: Action = { type: 'increment' }
 
 const component: ReducerComponent<{}> = reducerComponent('Counter')
 

--- a/test/Counter.test.tsx
+++ b/test/Counter.test.tsx
@@ -10,9 +10,9 @@ type State = number
 
 type Action = { type: 'increment' }
 
-const increment = { type: 'increment' }
+const increment: Action = { type: 'increment' }
 
-const component: ReducerComponent<{}> = reducerComponent('Counter')
+const component: ReducerComponent<{}, State, Action> = reducerComponent('Counter')
 
 const Counter = make(component, {
   initialState: 0,
@@ -23,7 +23,7 @@ const Counter = make(component, {
     }
   },
 
-  render: (self: Self<{}, State, Action>) =>
+  render: (self) =>
     <div>
       <span>{self.state}</span>
       <button id="counter-button" onClick={_capture(self, increment)}>Click</button>

--- a/test/Counter.test.tsx
+++ b/test/Counter.test.tsx
@@ -10,7 +10,7 @@ type State = number
 
 type Action = { type: 'increment' }
 
-const increment: Action = { type: 'increment' }
+const increment = { type: 'increment' }
 
 const component: ReducerComponent<{}> = reducerComponent('Counter')
 

--- a/test/Refs.test.tsx
+++ b/test/Refs.test.tsx
@@ -32,7 +32,7 @@ test('Ref can only be modified if it holds a value', () => {
 
 const component = reducerComponent('Test')
 
-const Test = make<{}, Ref<HTMLInputElement>, 'click' | 'rerender'>(component, {
+const Test = make<{}, Ref<HTMLInputElement>, 'click'>(component, {
   initialState: Ref.create(),
 
   reducer: (self, action) => update(self.state),

--- a/test/Refs.test.tsx
+++ b/test/Refs.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as Enzyme from 'enzyme'
 import { mount, shallow } from 'enzyme'
 import * as Adapter from 'enzyme-adapter-react-16'
-import { _capture, reducerComponent, make, update, Ref } from '..'
+import { _capture, reducerComponent, make, update, Ref, ReducerComponent } from '..'
 
 Enzyme.configure({adapter: new Adapter()})
 
@@ -30,10 +30,11 @@ test('Ref can only be modified if it holds a value', () => {
   expect(n).toEqual(2)
 })
 
-const component = reducerComponent('Test')
+const component: ReducerComponent<{}, Ref<HTMLInputElement>, 'click' | 'rerender'>
+  = reducerComponent('Test')
 
-const Test = make<{}, Ref<HTMLInputElement>, 'click'>(component, {
-  initialState: Ref.create(),
+const Test = make(component, {
+  initialState: Ref.create<HTMLInputElement>(),
 
   reducer: (self, action) => update(self.state),
 

--- a/test/Refs.test.tsx
+++ b/test/Refs.test.tsx
@@ -32,7 +32,7 @@ test('Ref can only be modified if it holds a value', () => {
 
 const component = reducerComponent('Test')
 
-const Test = make<{}, Ref<HTMLInputElement>, 'click'>(component, {
+const Test = make<{}, Ref<HTMLInputElement>, 'click' | 'rerender'>(component, {
   initialState: Ref.create(),
 
   reducer: (self, action) => update(self.state),


### PR DESCRIPTION
Add additional type parameter AA to tell compiler that given action
parameter should be a subtype of action A. The type parameter does not
need to be specified by the lib user, the compiler can infer it.