### PR TITLE
Send actions to parent reducer component through context

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from './src/reducer-component'
+export * from './src/action-context'
 export { Ref } from './src/refs'

--- a/src/action-context.tsx
+++ b/src/action-context.tsx
@@ -1,0 +1,68 @@
+import * as React from "react"
+import { ComponentSpec, send, Self } from "./reducer-component"
+
+export interface ActionContextProps<A> {
+  actionContext: ActionContext<A>
+}
+
+export interface ActionContext<A> {
+  sendAction(a: A): void
+}
+
+export type ComponentActionContext<A> = ActionContext<A> | null
+
+export interface ActionContextual<P, S, A> {
+  wrapInContext(componentSpec: ComponentSpec<P, S, A>): ComponentSpec<P, S, A>
+  withContext<PP>(WrappedComponent: React.ComponentType<PP & ActionContextProps<A>>): React.FunctionComponent<PP>
+}
+
+export function createActionContextual<P, S, A>(): ActionContextual<P, S, A> {
+  const context = React.createContext<ComponentActionContext<A>>(null)
+  return {
+    wrapInContext: withProviderContextWrapper(context.Provider),
+    withContext: withConsumerContext(context.Consumer)
+  }
+}
+
+function withProviderContextWrapper<P, S, A>(ActionContextProvider: React.Provider<ComponentActionContext<A>>):
+  (componentSpec: ComponentSpec<P, S, A>) => ComponentSpec<P, S, A> {
+  return (componentSpec: ComponentSpec<P, S, A>) => {
+    return {
+      ...componentSpec,
+      render(self) {
+        const sendAction = createSendAction(self)
+        return (
+          <ActionContextProvider value={{ sendAction }}>
+            {componentSpec.render(self)}
+          </ActionContextProvider>
+        )
+      }
+    }
+  }
+}
+
+function withConsumerContext<P extends {}, A>(Consumer: React.Consumer<ComponentActionContext<A>>): (WrappedComponent: React.ComponentType<P & ActionContextProps<A>>) => React.FunctionComponent<P> {
+  return (WrappedComponent) => {
+    return (props: P) => {
+      return (
+        <Consumer>
+          {(actionContext: ComponentActionContext<A>) => {
+            if (!actionContext) {
+              throw new Error("No action context provided!")
+            } else {
+              const wrappedProps: P & ActionContextProps<A> = { ...props, actionContext }
+              return (<WrappedComponent {...wrappedProps} />)
+            }
+          }}
+        </Consumer>
+      )
+    }
+  }
+}
+
+function createSendAction<P, S, A>(self: Self<P, S, A>): (action: A) => void {
+  return (action: A) => {
+    send(self, action)
+  }
+}
+

--- a/src/reducer-component.ts
+++ b/src/reducer-component.ts
@@ -1,4 +1,4 @@
-import { Component, EventHandler, ReactElement, SyntheticEvent, createElement } from 'react'
+import { Component, EventHandler, ReactElement, SyntheticEvent, createElement, Provider } from 'react'
 
 export type Self<props, state, action> = {
   readonly props: props
@@ -140,6 +140,23 @@ export function reducerComponent<P, S, A>(displayName: string): ReducerComponent
     static displayName: string
   }
   class_.displayName = displayName
+  return class_
+}
+
+export function providerReducerComponent<P, S, A, C>(displayName: string, ProviderComponentInstance: Provider<C>, contextValueCreator: (self: Self<P, S, A>) => C): ReducerComponent<P, S, A> {
+  const class_ = class extends ReducerComponentInstance<P, S, A> {
+    static displayName: string = displayName
+    private contextValue: C = contextValueCreator(this.toSelf())
+
+    render() {
+      return createElement(
+        ProviderComponentInstance,
+        { value: this.contextValue },
+        this.__spec.render(this.toSelf())
+      )
+    }
+  }
+
   return class_
 }
 

--- a/test/ActionContextCounter.test.tsx
+++ b/test/ActionContextCounter.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import * as Enzyme from 'enzyme'
 import { mount } from 'enzyme'
 import * as Adapter from 'enzyme-adapter-react-16'
-import { ReducerComponent, _capture, reducerComponent, make, updateAndSideEffects } from '..'
-import { ActionContextProps, createActionContextual } from '../src/action-context'
+import { ReducerComponent, _capture, make, updateAndSideEffects } from '..'
+import { ActionContextualComponentProps, createActionContextual } from '../src/action-context'
 import { ComponentSpec } from '../src/reducer-component'
 
 Enzyme.configure({adapter: new Adapter()})
@@ -12,14 +12,14 @@ type State = number
 
 type Action = { type: 'increment' }
 
-const component: ReducerComponent<{}, State, Action> = reducerComponent('Counter')
+const {reducerComponent, withContext} = createActionContextual<{}, State, Action>()
 
-const {wrapInContext, withContext} = createActionContextual<{}, State, Action>()
+const component: ReducerComponent<{}, State, Action> = reducerComponent('Counter')
 
 interface CounterButtonProps {
   label: string
 }
-const CounterButton = withContext((props: CounterButtonProps & ActionContextProps<Action>) => {
+const CounterButton = withContext((props: CounterButtonProps & ActionContextualComponentProps<Action>) => {
   return <button id="counter-button" onClick={() => {
     props.actionContext.sendAction({ type: "increment" })
   }}>{props.label}</button>
@@ -44,7 +44,7 @@ const componentSpec: ComponentSpec<{}, State, Action> = {
   }
 }
 
-const Counter = make(component, wrapInContext(componentSpec))
+const Counter = make(component, componentSpec)
 
 test('Reducer can be used to update state', () => {
   const counter = mount(<Counter />)

--- a/test/ActionContextCounter.test.tsx
+++ b/test/ActionContextCounter.test.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import * as Enzyme from 'enzyme'
+import { mount } from 'enzyme'
+import * as Adapter from 'enzyme-adapter-react-16'
+import { ReducerComponent, _capture, reducerComponent, make, updateAndSideEffects } from '..'
+import { ActionContextProps, createActionContextual } from '../src/action-context'
+import { ComponentSpec } from '../src/reducer-component'
+
+Enzyme.configure({adapter: new Adapter()})
+
+type State = number
+
+type Action = { type: 'increment' }
+
+const component: ReducerComponent<{}, State, Action> = reducerComponent('Counter')
+
+const {wrapInContext, withContext} = createActionContextual<{}, State, Action>()
+
+interface CounterButtonProps {
+  label: string
+}
+const CounterButton = withContext((props: CounterButtonProps & ActionContextProps<Action>) => {
+  return <button id="counter-button" onClick={() => {
+    props.actionContext.sendAction({ type: "increment" })
+  }}>{props.label}</button>
+})
+
+const componentSpec: ComponentSpec<{}, State, Action> = {
+  initialState: 0,
+
+  reducer(self, action) {
+    switch (action.type) {
+      case 'increment': return updateAndSideEffects(self.state + 1, updatedSelf => { })
+    }
+  },
+
+  render(self) {
+    return (
+      <div>
+        <span>{self.state}</span>
+        <CounterButton label="Click" />
+      </div>
+    )
+  }
+}
+
+const Counter = make(component, wrapInContext(componentSpec))
+
+test('Reducer can be used to update state', () => {
+  const counter = mount(<Counter />)
+  counter.find('button').simulate('click')
+  counter.find('button').simulate('click')
+  expect(counter.find('span').text()).toEqual("2")
+})


### PR DESCRIPTION
WIP PR for discussing implementation, not ready for merging yet. This branch is on top of `typescript-3.4` branch.

Pros:
- Using context is optional
- The whole component subtree can send actions through context using a HOC

Cons:
- You cannot statically type React contexts as is
- Context is now recreated (and Consumers rendered) with each render, should the context be defined outside render?